### PR TITLE
fix: #2 separate <Frame /> and #3 useRouter is not stale anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,18 @@ import { Route, StackRouter } from "./router";
 const App = () => {
   return (
     <StackRouter initialRouteName="Home">
-      <Route
-        name="Home"
-        component={Home}
-        initialParams={{
-          user: "@ammarahmed",
-        }}
-      />
+      <StackRouterFrame>
+        <Route
+          name="Home"
+          component={Home}
+          initialParams={{
+            user: "@ammarahmed",
+          }}
+        />
+      </StackRouterFrame>
+
+      {/* 👇 You can add components independent of the navigation frame that can still use `useRouter()`. */}
+      <BottomNavigation />
     </StackRouter>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,9 @@ export interface NavigationStackInternal<
 > {
   pushRoute: (route: NavigationRoute<Key, RouteName>) => void;
   removeRoute: (route: NavigationRoute<Key, RouteName>) => void;
+  setFrameRef: (ref: Frame | undefined) => void;
+  useTopMostFrame: () => boolean
+  frameProps?: () => Omit<JSX.IntrinsicElements["text"], "toString">;
 }
 
 export type RouteOptions = {


### PR DESCRIPTION
There were some issues with how `solid-navigation` was using `setStore`. Very easy mistake of not using `produce()`, so I just added it and it fixed some issues #2 and #3 .

In summary I made **1 fix** and **1 improvement**:
**1. Fix:** Used to be, only components inside `<Route />` can access, `useRouter`.  Anything outside of the `<Route />` but inside of `<StackRouter />` has a stale version of `useRouter`. The `produce()` syntax fixes this.

**2. Improvement:** I also decoupled the `<frame>` from the `<StackRouter>` provider so you can essentially control where the Frame can be set. So now I added a `<StackRouterFrame>`  so a structure like this is possible:
```tsx
<StackRouter>
  <StackRouterFrame>
     <Route />
     <Route />
     <Route />
  </StackRouterFrame>

  <BottomNavigation /> {/* Can now access useRouter without being part of the navigating frame. */}
</StackRouter>
```

For context: I was trying to solve this hack/workaround https://discord.com/channels/603595811204366337/1139698246088933459/1438535863679062106. Thanks @rigor789 for pointing me in this direction!


---

Btw I'll try to add `<StackRouterFrame>` in the readme too.